### PR TITLE
Requiring redux-persist/constants

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var constants = require('redux-persist/constants')
+var constants = require('redux-persist/lib/constants')
 var KEY_PREFIX = constants.KEY_PREFIX
 
 module.exports = function(persistor, config){


### PR DESCRIPTION
Change the way ```redux-persist/constants``` is required